### PR TITLE
limit number of messages sent to api and allow users set the max n

### DIFF
--- a/intellichat/src/app/api/chat/route.ts
+++ b/intellichat/src/app/api/chat/route.ts
@@ -21,9 +21,14 @@ export async function POST(req: Request) {
 
   if (!parsedJson.success) {
     const { error } = parsedJson;
-    return NextResponse.json({
-      error: { message: 'Invalid', error },
-    });
+    return NextResponse.json(
+      {
+        error: { message: 'Invalid', error },
+      },
+      {
+        status: 400,
+      }
+    );
   }
 
   const {
@@ -33,7 +38,8 @@ export async function POST(req: Request) {
     systemMessage = defaultSystemMessage,
   } = parsedJson.data;
 
-  const key = apiKeys[provider.name] || getChatProviderKey(provider.name);
+  const key =
+    (apiKeys && apiKeys[provider.name]) || getChatProviderKey(provider.name);
 
   if (!key) {
     return NextResponse.json(

--- a/intellichat/src/components/chat-settings.tsx
+++ b/intellichat/src/components/chat-settings.tsx
@@ -23,19 +23,23 @@ import { ChevronsUpDown } from 'lucide-react';
 import { Button } from './ui/button';
 
 export default function ChatSettings() {
+  const [areKeysVisible, setKeysVisibility] = React.useState(true);
+
   const systemMessage = useChatSettings((s) => s.systemMessage);
+  const numberOfMessages = useChatSettings((s) => s.numberOfMessages);
   const provider = useChatSettings((s) => s.provider);
   const openaikey = useChatSettings((s) => s.apiKeys.openai);
   const replicatekey = useChatSettings((s) => s.apiKeys.replicate);
-  const setKey = useChatSettings((s) => s.setKey);
+
   const updateSystemMessage = useChatSettings((s) => s.setSystemMessage);
+  const setNumberOfMessages = useChatSettings((s) => s.setNumberOfMessages);
+  const setKey = useChatSettings((s) => s.setKey);
   const updateProvider = useChatSettings((s) => s.setProvider);
   const updateModel = useChatSettings((s) => s.setModel);
-  const [areKeysVisible, setKeysVisibility] = React.useState(false);
 
   return (
     <div className='space-y-8'>
-      <div>
+      <div className='space-y-1'>
         <Label htmlFor='systemMsg'>System Message</Label>
         <Input
           id='systemMsg'
@@ -45,7 +49,7 @@ export default function ChatSettings() {
           }}
         />
       </div>
-      <div>
+      <div className='space-y-1'>
         <Label>Provider</Label>
         <Select
           value={provider.name}
@@ -68,7 +72,7 @@ export default function ChatSettings() {
           </SelectContent>
         </Select>
       </div>
-      <div>
+      <div className='space-y-1'>
         <Label>Models</Label>
         <Select
           value={provider.model}
@@ -90,6 +94,23 @@ export default function ChatSettings() {
             </SelectGroup>
           </SelectContent>
         </Select>
+      </div>
+      <div className='space-y-0'>
+        <Label htmlFor='systemMsg'>Number of Messages</Label>
+        <Input
+          id='systemMsg'
+          type='number'
+          min={4}
+          max={8}
+          value={numberOfMessages}
+          onChange={(e) => {
+            console.log(e.target.value);
+            setNumberOfMessages(parseInt(e.target.value));
+          }}
+        />
+        <p className='text-xs  text-zinc-300'>
+          number of messages to include in a request
+        </p>
       </div>
       <Separator orientation='horizontal' />
       <Collapsible

--- a/intellichat/src/components/shared/header.tsx
+++ b/intellichat/src/components/shared/header.tsx
@@ -8,7 +8,7 @@ type Props = {};
 export default function Header({}: Props) {
   return (
     <header className='sticky top-0 z-[60] bg-background py-8 shadow-sm'>
-      <Container className='flex items-center justify-between'>
+      <Container className='flex max-w-full items-center justify-between'>
         <div>
           <Logo />
         </div>

--- a/intellichat/src/lib/chat-providers.ts
+++ b/intellichat/src/lib/chat-providers.ts
@@ -1,11 +1,11 @@
-const openAIModels = ['gpt-3.5-turbo', 'gpt-4'];
+const openAIModels = ['gpt-3.5-turbo', 'gpt-4'] as const;
 const replicateModels = [
   '70b-chat',
   '13b-chat',
   '34b-code',
   '34b-python',
   '13b-code-instruct',
-];
+] as const;
 
 export const AIProviders: {
   openai: { name: 'openai'; models: typeof openAIModels };

--- a/intellichat/src/lib/validators.ts
+++ b/intellichat/src/lib/validators.ts
@@ -23,10 +23,12 @@ export const chatbotValidator = z.object({
       role: z.enum(['user', 'assistant']),
     })
   ),
-  apiKeys: z.object({
-    openai: z.string().optional(),
-    replicate: z.string().optional(),
-  }),
+  apiKeys: z
+    .object({
+      openai: z.string().optional(),
+      replicate: z.string().optional(),
+    })
+    .optional(),
   provider: z.union([openAI, replicate]).optional(),
   systemMessage: z.string().optional(),
 });

--- a/intellichat/src/store/chat-settings.ts
+++ b/intellichat/src/store/chat-settings.ts
@@ -21,11 +21,13 @@ type ChatSettingsState = {
   isSidebarOpen: boolean;
   systemMessage: string;
   provider: OpenAI | Replicate;
+  numberOfMessages: number;
   apiKeys: {
     openai: string;
     replicate: string;
   };
   setSystemMessage: (message: string) => void;
+  setNumberOfMessages: (numberOfMessages: number) => void;
   setProvider: (provider: 'openai' | 'replicate') => void;
   setModel: (model: OpenAI['model'] | Replicate['model']) => void;
   setKey: (provider: 'openai' | 'replicate', key: string) => void;
@@ -36,12 +38,17 @@ export const useChatSettings = create<ChatSettingsState>((set, get) => ({
   systemMessage: defaultSystemMessage,
   provider: defaultProvider,
   isSidebarOpen: false,
+  numberOfMessages: 4,
   apiKeys: {
     openai: '',
     replicate: '',
   },
   setSystemMessage: (message: string) => {
     set({ systemMessage: message });
+  },
+  setNumberOfMessages: (numberOfMessages: number) => {
+    if (numberOfMessages < 4 || numberOfMessages > 8) return;
+    set({ numberOfMessages });
   },
   setKey: (provider: 'openai' | 'replicate', key: string) => {
     set((state) => ({


### PR DESCRIPTION
- update chat-settings store to include numberOfMessages prop.
- update chat-settings UI to include a number of messages field.
- update the chat mutation to limit the messages sent to the API based on the numberOfMessages value.