### PR TITLE
25 add azure openai option

### DIFF
--- a/intellichat/intellinode.d.ts
+++ b/intellichat/intellinode.d.ts
@@ -2,10 +2,19 @@ declare module 'intellinode' {
   type SupportedChatModels = 'openai' | 'replicate' | 'sagemaker';
 
   class Chatbot {
-    constructor(keyValue?: string, provider?: string);
+    constructor(
+      keyValue?: string,
+      provider?: string,
+      customProxy?: ProxyHelper
+    );
     chat(modelInput?: ChatGPTInput | LLamaReplicateInput);
   }
   class ChatGPTInput {
+    model: string = 'gpt-3.5-turbo';
+    temperature: number = 1;
+    maxTokens: number | null = null;
+    numberOfOutputs: number = 1;
+
     constructor(
       systemMessage: string,
       options?: {
@@ -31,11 +40,20 @@ declare module 'intellinode' {
   }
 
   class ChatContext {
-    constructor(apiKey: string, provider?: SupportedChatModels);
+    constructor(
+      apiKey: string,
+      provider?: SupportedChatModels,
+      customProxy?: ProxyHelper | null
+    );
     getRoleContext(
       userMessage: string,
       historyMessages: { role: 'user' | 'assistant'; content: string }[],
-      n: number
+      n: number,
+      embeddingName?: string | null
     );
+  }
+  class ProxyHelper {
+    static getInstance(): ProxyHelper;
+    setAzureOpenai(resourceName: string): void;
   }
 }

--- a/intellichat/package.json
+++ b/intellichat/package.json
@@ -30,7 +30,7 @@
     "clsx": "2.0.0",
     "eslint": "8.48.0",
     "eslint-config-next": "13.4.19",
-    "intellinode": "1.4.3",
+    "intellinode": "1.4.4",
     "lucide-react": "0.274.0",
     "nanoid": "4.0.2",
     "next": "13.4.19",

--- a/intellichat/src/app/api/azure-context/route.ts
+++ b/intellichat/src/app/api/azure-context/route.ts
@@ -1,0 +1,61 @@
+import { addMessages } from '@/lib/intellinode';
+import { ChatContext, ChatGPTInput, Chatbot, ProxyHelper } from 'intellinode';
+import { NextResponse } from 'next/server';
+
+export async function GET() {
+  const apiKey = '7f2d662bcae44c6f825758b176a257e0';
+  const resourceName = 'medwrite-openai';
+  const modelName = 'gpt_basic'; // input
+  const embeddingName = 'embed_latest'; // context
+
+  const proxy = new ProxyHelper();
+  proxy.setAzureOpenai(resourceName);
+
+  // chatbot
+  const chatbot = new Chatbot(apiKey, 'openai', proxy);
+  const context = new ChatContext(apiKey, 'openai', proxy);
+
+  const system = 'You are a helpful assistant.';
+  const input = new ChatGPTInput(system, {
+    model: modelName,
+  });
+  const userMessage = 'Hello';
+  const historyMessages: {
+    role: 'user' | 'assistant';
+    content: string;
+  }[] = [
+    { role: 'user', content: 'Dinner time' },
+    { role: 'assistant', content: 'Hi there!' },
+    { role: 'user', content: 'Good Morning' },
+    { role: 'assistant', content: 'How can I help you' },
+  ];
+  try {
+    const contextResponse = await context.getRoleContext(
+      userMessage,
+      historyMessages,
+      2,
+      embeddingName
+    );
+    addMessages(input, contextResponse);
+    const responses = await chatbot.chat(input);
+
+    return NextResponse.json(
+      {
+        response: responses[0],
+      },
+      {
+        status: 200,
+      }
+    );
+  } catch (e) {
+    console.log(e);
+    return NextResponse.json(
+      {
+        response: e,
+      },
+      {
+        status: 200,
+      }
+    );
+  }
+}

--- a/intellichat/src/components/chat-prompt.tsx
+++ b/intellichat/src/components/chat-prompt.tsx
@@ -13,6 +13,7 @@ export const ChatPrompt = React.forwardRef<HTMLTextAreaElement, Props>(
     const { isLoading, onSubmit } = props;
 
     const onEnter = (event: React.KeyboardEvent<HTMLTextAreaElement>) => {
+      if (isLoading) return;
       if (event.key === 'Enter') {
         event.preventDefault();
         onSubmit();
@@ -39,6 +40,7 @@ export const ChatPrompt = React.forwardRef<HTMLTextAreaElement, Props>(
             className='absolute right-4 top-3 h-11 w-16 p-0'
             onClick={onSubmit}
             variant='default'
+            disabled={isLoading}
           >
             <CornerDownLeft />
           </Button>

--- a/intellichat/src/components/chat-settings.tsx
+++ b/intellichat/src/components/chat-settings.tsx
@@ -5,12 +5,7 @@ import { z } from 'zod';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 
-import {
-  OpenAI,
-  Replicate,
-  openAIModels,
-  replicateModels,
-} from '@/lib/chat-providers';
+import { Azure, OpenAI, Replicate } from '@/lib/chat-providers';
 
 import { useChatSettings } from '@/store/chat-settings';
 import { AIProviderType, AIProviders } from '@/lib/chat-providers';
@@ -31,7 +26,6 @@ import FieldTooltip from '@/components/field-tooltip';
 import {
   Form,
   FormControl,
-  FormDescription,
   FormField,
   FormItem,
   FormLabel,
@@ -44,10 +38,14 @@ const formSchema = z
   .object({
     systemMessage: z.string(),
     numberOfMessages: z.number(),
-    providerName: z.string(),
+    providerName: z.enum(['openai', 'replicate', 'azure']),
     providerModel: z.string(),
     openaiKey: z.string(),
     replicateKey: z.string(),
+    azureKey: z.string(),
+    azureResourceName: z.string(),
+    azureModelName: z.string(),
+    azureEmbeddingName: z.string(),
     withContext: z.boolean(),
     envKeyExist: z.object({
       openai: z.boolean(),
@@ -79,28 +77,30 @@ const formSchema = z
     }
   });
 
-export default function ChatSettings({
-  closeSidebar,
-}: {
-  closeSidebar: () => void;
-}) {
+export default function ChatSettings() {
   const systemMessage = useChatSettings((s) => s.systemMessage);
   const numberOfMessages = useChatSettings((s) => s.numberOfMessages);
   const provider = useChatSettings((s) => s.provider);
-  const openaikey = useChatSettings((s) => s.apiKeys.openai);
-  const replicatekey = useChatSettings((s) => s.apiKeys.replicate);
+  const openai = useChatSettings((s) => s.openai);
+  const replicate = useChatSettings((s) => s.replicate);
+  const azure = useChatSettings((s) => s.azure);
   const withContext = useChatSettings((s) => s.withContext);
   const envKeyExist = useChatSettings((s) => s.envKeyExist);
+  const getModel = useChatSettings((s) => s.getModel);
   const updateChatSettings = useChatSettings((s) => s.updateChatSettings);
 
   const form = useForm<z.infer<typeof formSchema>>({
     defaultValues: {
       systemMessage,
       numberOfMessages,
-      providerName: provider.name,
-      providerModel: provider.model,
-      openaiKey: openaikey,
-      replicateKey: replicatekey,
+      providerName: provider,
+      providerModel: getModel(provider),
+      openaiKey: openai.apiKey,
+      replicateKey: replicate.apiKey,
+      azureKey: azure.apiKey,
+      azureResourceName: azure.resourceName,
+      azureModelName: azure.model,
+      azureEmbeddingName: azure.embeddingName,
       withContext,
       envKeyExist: {
         openai: envKeyExist.openai,
@@ -116,31 +116,61 @@ export default function ChatSettings({
     providerModel,
     openaiKey,
     replicateKey,
+    azureEmbeddingName,
+    azureResourceName,
+    azureModelName,
+    azureKey,
     ...values
   }: z.infer<typeof formSchema>) {
-    let provider: OpenAI | Replicate;
-
-    if (providerName === 'openai') {
-      provider = {
-        name: providerName,
-        model: providerModel as OpenAI['model'],
-      };
-    } else {
-      provider = {
-        name: 'replicate',
-        model: providerModel as Replicate['model'],
-      };
-    }
+    const provider = providerName;
     updateChatSettings({
       provider,
-      apiKeys: {
-        openai: openaiKey,
-        replicate: replicateKey,
+      openai: {
+        ...openai,
+        apiKey: openaiKey,
+        model:
+          provider === 'openai'
+            ? (providerModel as OpenAI['model'])
+            : openai.model,
+      },
+      replicate: {
+        ...replicate,
+        apiKey: replicateKey,
+        model:
+          provider === 'replicate'
+            ? (providerModel as Replicate['model'])
+            : replicate.model,
+      },
+      azure: {
+        ...azure,
+        apiKey: azureKey,
+        resourceName: azureResourceName,
+        model: azureModelName,
+        embeddingName: azureEmbeddingName,
       },
       ...values,
     });
-    closeSidebar();
   }
+
+  function onChangeProviderName(name: string) {
+    const providerName = name as 'openai' | 'replicate' | 'azure';
+    form.setValue('providerName', providerName);
+
+    if (providerName !== 'azure') {
+      form.setValue(
+        'providerModel',
+        AIProviders[providerName].models[0] as string
+      );
+    }
+
+    if (providerName === 'openai' || providerName === 'azure') {
+      form.setValue('withContext', true);
+    } else {
+      form.setValue('withContext', false);
+    }
+  }
+
+  const watchProviderName = form.watch('providerName');
 
   return (
     <ScrollArea className='h-full'>
@@ -187,6 +217,7 @@ export default function ChatSettings({
               </FormItem>
             )}
           />
+
           <FormField
             control={form.control}
             name='providerName'
@@ -197,14 +228,11 @@ export default function ChatSettings({
                   <Select
                     onValueChange={(e) => {
                       field.onChange(e);
-                      form.setValue(
-                        'providerModel',
-                        AIProviders[e as keyof AIProviderType].models[0]
-                      );
+                      onChangeProviderName(e);
                     }}
                     defaultValue={field.value}
                   >
-                    <SelectTrigger className='w-[180px]'>
+                    <SelectTrigger>
                       <SelectValue placeholder='Select a Model' />
                     </SelectTrigger>
                     <SelectContent>
@@ -214,6 +242,7 @@ export default function ChatSettings({
                             {AIProviders[key as keyof typeof AIProviders].name}
                           </SelectItem>
                         ))}
+                        <SelectItem value={'azure'}>azure</SelectItem>
                       </SelectGroup>
                     </SelectContent>
                   </Select>
@@ -222,37 +251,116 @@ export default function ChatSettings({
               </FormItem>
             )}
           />
-          <FormField
-            control={form.control}
-            name='providerModel'
-            render={({ field }) => (
-              <FormItem>
-                <FormLabel>Model</FormLabel>
-                <FormControl>
-                  <Select
-                    onValueChange={field.onChange}
-                    defaultValue={field.value}
-                  >
-                    <SelectTrigger className='w-[180px]'>
-                      <SelectValue>{field.value}</SelectValue>
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectGroup>
-                        {AIProviders[
-                          form.watch('providerName') as keyof AIProviderType
-                        ].models.map((model) => (
-                          <SelectItem key={model} value={model}>
-                            {model}
-                          </SelectItem>
-                        ))}
-                      </SelectGroup>
-                    </SelectContent>
-                  </Select>
-                </FormControl>
-                <FormMessage />
-              </FormItem>
-            )}
-          />
+
+          {watchProviderName !== 'azure' && (
+            <FormField
+              control={form.control}
+              name='providerModel'
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Model</FormLabel>
+                  <FormControl>
+                    <Select
+                      onValueChange={field.onChange}
+                      defaultValue={field.value}
+                    >
+                      <SelectTrigger>
+                        <SelectValue>{field.value}</SelectValue>
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectGroup>
+                          {AIProviders[
+                            form.watch('providerName') as keyof AIProviderType
+                          ].models.map((model) => (
+                            <SelectItem key={model} value={model}>
+                              {model}
+                            </SelectItem>
+                          ))}
+                        </SelectGroup>
+                      </SelectContent>
+                    </Select>
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          )}
+          {watchProviderName == 'azure' && (
+            <div className='space-y-4'>
+              <FormField
+                control={form.control}
+                name='azureKey'
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Azure API Key</FormLabel>
+                    <FormControl>
+                      <Input {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name='azureResourceName'
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Azure Resource Name</FormLabel>
+                    <FormControl>
+                      <Input {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name='azureModelName'
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Azure Model Name</FormLabel>
+                    <FormControl>
+                      <Input {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name='azureEmbeddingName'
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Azure Embedding Name</FormLabel>
+                    <FormControl>
+                      <Input {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </div>
+          )}
+          {watchProviderName !== 'azure' && (
+            <>
+              <ApiKeyInput
+                control={form.control}
+                id='replicate'
+                name='replicateKey'
+                label='Replicate API Key'
+                provider={form.watch('providerName') as keyof AIProviderType}
+                withContext={form.watch('withContext')}
+              />
+              <ApiKeyInput
+                control={form.control}
+                id='openai'
+                name='openaiKey'
+                label='OpenAI API Key'
+                provider={form.watch('providerName') as keyof AIProviderType}
+                withContext={form.watch('withContext')}
+              />
+            </>
+          )}
           <FormField
             control={form.control}
             name='withContext'
@@ -275,23 +383,6 @@ export default function ChatSettings({
                 </FieldTooltip>
               </FormItem>
             )}
-          />
-          <ApiKeyInput
-            control={form.control}
-            id='openai'
-            name='openaiKey'
-            label='OpenAI API Key'
-            provider={form.watch('providerName') as keyof AIProviderType}
-            withContext={form.watch('withContext')}
-          />
-
-          <ApiKeyInput
-            control={form.control}
-            id='replicate'
-            name='replicateKey'
-            label='Replicate API Key'
-            provider={form.watch('providerName') as keyof AIProviderType}
-            withContext={form.watch('withContext')}
           />
           <Button type='submit'>Save</Button>
         </form>

--- a/intellichat/src/components/chat-settings.tsx
+++ b/intellichat/src/components/chat-settings.tsx
@@ -37,7 +37,7 @@ import ApiKeyInput from './apikey-input';
 const formSchema = z
   .object({
     systemMessage: z.string(),
-    numberOfMessages: z.number(),
+    numberOfMessages: z.number().min(2).max(6),
     providerName: z.enum(['openai', 'replicate', 'azure']),
     providerModel: z.string(),
     openaiKey: z.string(),
@@ -210,6 +210,8 @@ export default function ChatSettings() {
                   <Input
                     {...field}
                     type='number'
+                    min={2}
+                    max={6}
                     onChange={(e) => field.onChange(parseInt(e.target.value))}
                   />
                 </FormControl>

--- a/intellichat/src/components/chat.tsx
+++ b/intellichat/src/components/chat.tsx
@@ -13,12 +13,8 @@ import { useToast } from './ui/use-toast';
 
 export default function Chat() {
   const [messages, setMessages] = React.useState<Message[]>([]);
-  const provider = useChatSettings((s) => s.provider);
-  const systemMessage = useChatSettings((s) => s.systemMessage);
-  const numberOfMessages = useChatSettings((s) => s.numberOfMessages);
-  const apiKeys = useChatSettings((s) => s.apiKeys);
+  const getSettings = useChatSettings((s) => s.getSettings);
   const setEnvKeyExist = useChatSettings((s) => s.setEnvKeyExist);
-  const withContext = useChatSettings((s) => s.withContext);
 
   const { toast } = useToast();
 
@@ -26,14 +22,17 @@ export default function Chat() {
 
   const { mutate, isLoading } = useMutation({
     mutationFn: async (messages: Message[]) => {
+      const { n, provider, providers, systemMessage, withContext } =
+        getSettings();
       const payload: PostMessagePayload = {
         messages,
         provider,
+        providers,
         systemMessage,
-        apiKeys,
         withContext,
-        n: numberOfMessages,
+        n,
       };
+      console.log(payload.provider);
       const res = await fetch('/api/chat', {
         method: 'POST',
         body: JSON.stringify(payload),

--- a/intellichat/src/components/shared/sidebar.tsx
+++ b/intellichat/src/components/shared/sidebar.tsx
@@ -2,6 +2,10 @@
 
 import React, { useEffect } from 'react';
 import { usePathname } from 'next/navigation';
+import { PanelLeftOpen, PanelLeftClose } from 'lucide-react';
+
+import { useChatSettings } from '@/store/chat-settings';
+
 import {
   Sheet,
   SheetContent,
@@ -10,21 +14,19 @@ import {
   SheetTrigger,
 } from '@/components/ui/sheet';
 import { Button } from '@/components/ui/button';
-import { Settings } from 'lucide-react';
 import ChatSettings from '@/components/chat-settings';
-import { useChatSettings } from '@/store/chat-settings';
 import { TooltipProvider } from '@/components/ui/tooltip';
 
 export default function SideBar({ title }: { title?: string }) {
   const [isOpen, setIsOpen] = React.useState(false);
   const pathname = usePathname();
   const envKeyExist = useChatSettings((s) => s.envKeyExist);
-  const apiKeys = useChatSettings((s) => s.apiKeys);
+  const getProvider = useChatSettings((s) => s.getProvider);
   const provider = useChatSettings((s) => s.provider);
 
   // Open the settings sheet if the user has not set the API keys
   useEffect(() => {
-    if (!envKeyExist[provider.name] && apiKeys[provider.name].trim() === '') {
+    if (!envKeyExist[provider] && getProvider(provider).apiKey.trim() === '') {
       setIsOpen(true);
     }
   }, []);
@@ -33,7 +35,11 @@ export default function SideBar({ title }: { title?: string }) {
     <Sheet modal={false} open={isOpen} onOpenChange={() => setIsOpen(!isOpen)}>
       <SheetTrigger asChild>
         <Button variant='ghost' className='p-0 px-2'>
-          <Settings className='h-6 w-6' />
+          {isOpen ? (
+            <PanelLeftOpen className='h-6 w-6' />
+          ) : (
+            <PanelLeftClose className='h-6 w-6' />
+          )}
           <span className='sr-only'>Toggle Settings</span>
         </Button>
       </SheetTrigger>
@@ -47,11 +53,7 @@ export default function SideBar({ title }: { title?: string }) {
               <SheetTitle>{title}</SheetTitle>
             </SheetHeader>
             <TooltipProvider>
-              <ChatSettings
-                closeSidebar={() => {
-                  setIsOpen(false);
-                }}
-              />
+              <ChatSettings />
             </TooltipProvider>
           </>
         )}

--- a/intellichat/src/lib/chat-providers.ts
+++ b/intellichat/src/lib/chat-providers.ts
@@ -23,11 +23,21 @@ export const defaultProvider = {
 export type AIProviderType = typeof AIProviders;
 
 export type OpenAI = {
-  name: AIProviderType['openai']['name'];
+  name: 'openai';
   model: AIProviderType['openai']['models'][number];
+  apiKey: string;
 };
 
 export type Replicate = {
-  name: AIProviderType['replicate']['name'];
+  name: 'replicate';
   model: AIProviderType['replicate']['models'][number];
+  apiKey: string;
+};
+
+export type Azure = {
+  name: 'azure';
+  model: string;
+  resourceName: string;
+  embeddingName: string;
+  apiKey: string;
 };

--- a/intellichat/src/lib/intellinode.ts
+++ b/intellichat/src/lib/intellinode.ts
@@ -1,25 +1,143 @@
-import { ChatGPTInput, LLamaReplicateInput } from 'intellinode';
+import {
+  ChatContext,
+  ChatGPTInput,
+  Chatbot,
+  LLamaReplicateInput,
+  ProxyHelper,
+} from 'intellinode';
 import { ChatProvider } from './types';
+import {
+  azureType,
+  azureValidator,
+  openAIType,
+  openAIValidator,
+  replicateType,
+  replicateValidator,
+} from './validators';
 
-export function getChatInput(
-  provider: string,
-  model: string,
-  systemMessage: string
-) {
+export function getChatProviderKey(provider: ChatProvider) {
   if (provider === 'openai') {
-    return new ChatGPTInput(systemMessage, {
-      model: model,
-    });
+    return process.env.OPENAI_API_KEY;
   } else if (provider === 'replicate') {
-    return new LLamaReplicateInput(systemMessage, {
-      model: model,
-    });
+    return process.env.REPLICATE_API_KEY;
+  } else if (provider === 'azure') {
+    return process.env.AZURE_API_KEY;
   } else {
     throw new Error('provider is not supported');
   }
 }
 
-export function addMessages(
+type getAzureChatResponseParams = {
+  systemMessage: string;
+  messages: {
+    role: 'user' | 'assistant';
+    content: string;
+  }[];
+  provider?: azureType;
+  withContext: boolean;
+  n: number;
+};
+
+export async function getAzureChatResponse({
+  systemMessage,
+  messages,
+  provider,
+  withContext,
+  n,
+}: getAzureChatResponseParams) {
+  const parsed = azureValidator.safeParse(provider);
+
+  if (!parsed.success) {
+    const { error } = parsed;
+    throw new Error(error.message);
+  }
+
+  const { apiKey, resourceName, model, embeddingName, name } = parsed.data;
+  const proxy = createProxy(resourceName);
+  const chatbot = new Chatbot(apiKey, 'openai', proxy);
+  const input = getChatInput(name, model, systemMessage);
+
+  if (withContext) {
+    const contextResponse = await getContextResponse({
+      apiKey,
+      proxy,
+      messages,
+      model: embeddingName,
+    });
+    addMessages(input, contextResponse);
+  } else {
+    addMessages(input, messages);
+  }
+
+  const responses = await chatbot.chat(input);
+  return responses[0];
+}
+
+type getChatResponseParams = {
+  systemMessage: string;
+  messages: {
+    role: 'user' | 'assistant';
+    content: string;
+  }[];
+  provider?: openAIType | replicateType;
+  withContext: boolean;
+  n: number;
+  contextKey: string;
+};
+
+export async function getChatResponse({
+  systemMessage,
+  messages,
+  provider,
+  withContext,
+  n,
+  contextKey,
+}: getChatResponseParams) {
+  if (!provider) {
+    throw new Error('provider is required');
+  }
+  const parsed =
+    provider.name === 'openai'
+      ? openAIValidator.safeParse(provider)
+      : replicateValidator.safeParse(provider);
+
+  if (!parsed.success) {
+    const { error } = parsed;
+    throw new Error(error.message);
+  }
+
+  const { apiKey, model, name } = parsed.data;
+
+  const chatbot = new Chatbot(apiKey, name);
+  const input = getChatInput(name, model, systemMessage);
+
+  if (withContext) {
+    const contextResponse = await getContextResponse({
+      apiKey: contextKey,
+      messages,
+      n,
+    });
+    addMessages(input, contextResponse);
+  } else {
+    addMessages(input, messages);
+  }
+  const responses = await chatbot.chat(input);
+  return responses[0];
+}
+
+function getChatInput(provider: string, model: string, systemMessage: string) {
+  switch (provider) {
+    case 'openai':
+    case 'azure':
+      return new ChatGPTInput(systemMessage, { model });
+    case 'replicate':
+      return new LLamaReplicateInput(systemMessage, { model });
+    default:
+      throw new Error('provider is not supported');
+  }
+}
+
+function addMessages(
   chatInput: ChatGPTInput | LLamaReplicateInput,
   messages: {
     role: 'user' | 'assistant';
@@ -35,12 +153,38 @@ export function addMessages(
   });
 }
 
-export function getChatProviderKey(provider: ChatProvider) {
-  if (provider === 'openai') {
-    return process.env.OPENAI_API_KEY;
-  } else if (provider === 'replicate') {
-    return process.env.REPLICATE_API_KEY;
-  } else {
-    throw new Error('provider is not supported');
-  }
+function createProxy(resourceName: string) {
+  const proxy = new ProxyHelper();
+  proxy.setAzureOpenai(resourceName);
+  return proxy;
+}
+
+async function getContextResponse({
+  apiKey,
+  proxy = null,
+  messages,
+  model,
+  n = 2,
+}: {
+  apiKey: string;
+  messages: {
+    role: 'user' | 'assistant';
+    content: string;
+  }[];
+  proxy?: ProxyHelper | null;
+  model?: string | null;
+  n?: number;
+}) {
+  const context = new ChatContext(apiKey, 'openai', proxy);
+  // extract the last message from the array; this is the user's message
+  const userMessage = messages[messages.length - 1].content;
+
+  // get the closest context to the user's message
+  const contextResponse = await context.getRoleContext(
+    userMessage,
+    messages,
+    n,
+    model
+  );
+  return contextResponse;
 }

--- a/intellichat/src/lib/types.ts
+++ b/intellichat/src/lib/types.ts
@@ -4,4 +4,4 @@ export type Message = {
   role: 'user' | 'assistant';
 };
 
-export type ChatProvider = 'openai' | 'replicate';
+export type ChatProvider = 'openai' | 'replicate' | 'azure';

--- a/intellichat/src/lib/validators.ts
+++ b/intellichat/src/lib/validators.ts
@@ -1,11 +1,12 @@
 import { z } from 'zod';
 
-const openAI = z.object({
+export const openAIValidator = z.object({
   name: z.literal('openai'),
   model: z.enum(['gpt-3.5-turbo', 'gpt-4']),
+  apiKey: z.string(),
 });
 
-const replicate = z.object({
+export const replicateValidator = z.object({
   name: z.literal('replicate'),
   model: z.enum([
     '70b-chat',
@@ -14,6 +15,15 @@ const replicate = z.object({
     '34b-python',
     '13b-code-instruct',
   ]),
+  apiKey: z.string(),
+});
+
+export const azureValidator = z.object({
+  name: z.literal('azure'),
+  model: z.string(),
+  resourceName: z.string(),
+  embeddingName: z.string(),
+  apiKey: z.string(),
 });
 
 export const chatbotValidator = z.object({
@@ -23,16 +33,20 @@ export const chatbotValidator = z.object({
       role: z.enum(['user', 'assistant']),
     })
   ),
-  apiKeys: z
-    .object({
-      openai: z.string().optional(),
-      replicate: z.string().optional(),
-    })
-    .optional(),
-  provider: z.union([openAI, replicate]).optional(),
+  provider: z.enum(['openai', 'replicate', 'azure']),
+  providers: z.object({
+    openai: openAIValidator.optional(),
+    replicate: replicateValidator.optional(),
+    azure: azureValidator.optional(),
+  }),
+
   systemMessage: z.string().optional(),
   withContext: z.boolean(),
   n: z.number().optional(),
 });
+
+export type azureType = z.infer<typeof azureValidator>;
+export type openAIType = z.infer<typeof openAIValidator>;
+export type replicateType = z.infer<typeof replicateValidator>;
 
 export type PostMessagePayload = z.infer<typeof chatbotValidator>;

--- a/intellichat/src/store/chat-settings.ts
+++ b/intellichat/src/store/chat-settings.ts
@@ -1,19 +1,25 @@
-import { OpenAI, Replicate, defaultProvider } from '@/lib/chat-providers';
+import { Azure, OpenAI, Replicate } from '@/lib/chat-providers';
+import {
+  PostMessagePayload,
+  azureType,
+  openAIType,
+  replicateType,
+} from '@/lib/validators';
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 
 type ChatSettingsState = {
   isSidebarOpen: boolean;
   systemMessage: string;
-  provider: OpenAI | Replicate;
+  provider: 'openai' | 'replicate' | 'azure';
   numberOfMessages: number;
-  apiKeys: {
-    openai: string;
-    replicate: string;
-  };
+  openai: openAIType;
+  replicate: replicateType;
+  azure: azureType;
   envKeyExist: {
     openai: boolean;
     replicate: boolean;
+    azure: boolean;
   };
   withContext: boolean;
   setEnvKeyExist: ({
@@ -23,6 +29,9 @@ type ChatSettingsState = {
     openai: boolean;
     replicate: boolean;
   }) => void;
+  getModel: (provider: 'openai' | 'replicate' | 'azure') => string;
+  getSettings: () => Omit<PostMessagePayload, 'messages'>;
+  getProvider: (provider: 'openai' | 'replicate' | 'azure') => any;
   updateChatSettings: (settings: Partial<ChatSettingsState>) => void;
   toggleSidebar: () => void;
 };
@@ -32,16 +41,67 @@ export const useChatSettings = create<ChatSettingsState>()(
     (set, get) => ({
       withContext: true,
       systemMessage: '',
-      provider: defaultProvider,
+      provider: 'openai',
       isSidebarOpen: false,
       numberOfMessages: 4,
-      apiKeys: {
-        openai: '',
-        replicate: '',
+      azure: {
+        name: 'azure',
+        model: '',
+        resourceName: '',
+        embeddingName: '',
+        apiKey: '',
+      },
+      openai: {
+        name: 'openai',
+        model: 'gpt-3.5-turbo',
+        apiKey: '',
+      },
+      replicate: {
+        name: 'replicate',
+        model: '70b-chat',
+        apiKey: '',
       },
       envKeyExist: {
         openai: false,
         replicate: false,
+        azure: false,
+      },
+      getSettings: () => {
+        const provider = get().provider;
+        let settings: Omit<PostMessagePayload, 'messages'> = {
+          provider,
+          providers: {
+            openai: get().openai,
+            replicate: get().replicate,
+            azure: get().azure,
+          },
+          systemMessage: get().systemMessage,
+          n: get().numberOfMessages,
+          withContext: get().withContext,
+        };
+        return settings;
+      },
+      getProvider: (provider: 'openai' | 'replicate' | 'azure') => {
+        if (provider === 'openai') {
+          return get().openai;
+        } else if (provider === 'replicate') {
+          return get().replicate;
+        } else if (provider === 'azure') {
+          return get().azure;
+        } else {
+          throw new Error('provider is not supported');
+        }
+      },
+      getModel: (provider: 'openai' | 'replicate' | 'azure') => {
+        if (provider === 'openai') {
+          return get().openai.model;
+        } else if (provider === 'replicate') {
+          return get().replicate.model;
+        } else if (provider === 'azure') {
+          return get().azure.model;
+        } else {
+          throw new Error('provider is not supported');
+        }
       },
       updateChatSettings: (settings: Partial<ChatSettingsState>) => {
         set((state) => ({


### PR DESCRIPTION
- Refactored chat settings state and  cleaned up how providers are accessed
- Refactored chat UI to use the new state definitions
- Update the chat settings component to add the Azure OpenAi fields.
- Update Intellinode's util and included new helpers: `createProxy`, `getContextResponse`, `getAzureChatResponse`
and , `getChatResponse`.
- Minor styling improvements.
- Minor UX improvements.