### PR TITLE
Fix state errors

### DIFF
--- a/intellichat/src/components/chat-settings.tsx
+++ b/intellichat/src/components/chat-settings.tsx
@@ -94,7 +94,7 @@ export default function ChatSettings() {
       systemMessage,
       numberOfMessages,
       providerName: provider,
-      providerModel: getModel(provider),
+      providerModel: getModel(),
       openaiKey: openai.apiKey,
       replicateKey: replicate.apiKey,
       azureKey: azure.apiKey,

--- a/intellichat/src/components/shared/sidebar.tsx
+++ b/intellichat/src/components/shared/sidebar.tsx
@@ -20,16 +20,18 @@ import { TooltipProvider } from '@/components/ui/tooltip';
 export default function SideBar({ title }: { title?: string }) {
   const [isOpen, setIsOpen] = React.useState(false);
   const pathname = usePathname();
-  const envKeyExist = useChatSettings((s) => s.envKeyExist);
+  const getExistsInEnv = useChatSettings((s) => s.getExistsInEnv);
   const getProvider = useChatSettings((s) => s.getProvider);
   const provider = useChatSettings((s) => s.provider);
-  const providerkey = getProvider(provider).apiKey;
+  const providerkey = getProvider().apiKey;
   // Open the settings sheet if the user has not set the API keys
   useEffect(() => {
-    if (!envKeyExist[provider] && providerkey.trim() === '') {
+    const exists = getExistsInEnv();
+    const key = providerkey.trim();
+    if (!exists && key === '') {
       setIsOpen(true);
     }
-  }, [provider, envKeyExist, providerkey]);
+  }, [provider, getExistsInEnv, providerkey]);
 
   return (
     <Sheet modal={false} open={isOpen} onOpenChange={() => setIsOpen(!isOpen)}>

--- a/intellichat/src/store/chat-settings.ts
+++ b/intellichat/src/store/chat-settings.ts
@@ -29,9 +29,10 @@ type ChatSettingsState = {
     openai: boolean;
     replicate: boolean;
   }) => void;
-  getModel: (provider: 'openai' | 'replicate' | 'azure') => string;
+  getModel: () => string;
+  getExistsInEnv: () => boolean;
   getSettings: () => Omit<PostMessagePayload, 'messages'>;
-  getProvider: (provider: 'openai' | 'replicate' | 'azure') => any;
+  getProvider: () => Azure | OpenAI | Replicate;
   updateChatSettings: (settings: Partial<ChatSettingsState>) => void;
   toggleSidebar: () => void;
 };
@@ -66,6 +67,10 @@ export const useChatSettings = create<ChatSettingsState>()(
         replicate: false,
         azure: false,
       },
+      getExistsInEnv: () => {
+        const provider = get().provider;
+        return get().envKeyExist[provider];
+      },
       getSettings: () => {
         const provider = get().provider;
         let settings: Omit<PostMessagePayload, 'messages'> = {
@@ -81,7 +86,8 @@ export const useChatSettings = create<ChatSettingsState>()(
         };
         return settings;
       },
-      getProvider: (provider: 'openai' | 'replicate' | 'azure') => {
+      getProvider: () => {
+        const provider = get().provider;
         if (provider === 'openai') {
           return get().openai;
         } else if (provider === 'replicate') {
@@ -94,7 +100,8 @@ export const useChatSettings = create<ChatSettingsState>()(
           return get().openai;
         }
       },
-      getModel: (provider: 'openai' | 'replicate' | 'azure') => {
+      getModel: () => {
+        const provider = get().provider;
         if (provider === 'openai') {
           return get().openai.model;
         } else if (provider === 'replicate') {
@@ -102,7 +109,9 @@ export const useChatSettings = create<ChatSettingsState>()(
         } else if (provider === 'azure') {
           return get().azure.model;
         } else {
-          throw new Error('provider is not supported');
+          // return default model
+          console.log('returning default model');
+          return get().openai.model;
         }
       },
       updateChatSettings: (settings: Partial<ChatSettingsState>) => {


### PR DESCRIPTION
- changed the `getProvider` and `getModel` implementation in chat-settings store to access `provider` using `get()` instead of the passed argument. 
- added a new `getExistsInEnv` selector to check if the env var exits.
- updated the components to use the new implementation.