### PR TITLE
77 support custom rag url

### DIFF
--- a/intellichat/intellinode.d.ts
+++ b/intellichat/intellinode.d.ts
@@ -16,6 +16,7 @@ declare module 'intellinode' {
       customProxy?: ProxyHelper | null,
       options?: {
         oneKey?: string;
+        intelliBase?: string;
       }
     );
     chat(

--- a/intellichat/package.json
+++ b/intellichat/package.json
@@ -31,7 +31,7 @@
     "clsx": "2.0.0",
     "eslint": "8.48.0",
     "eslint-config-next": "13.4.19",
-    "intellinode": "^2.1.0",
+    "intellinode": "^2.2.6",
     "lucide-react": "0.274.0",
     "nanoid": "4.0.2",
     "next": "13.4.19",

--- a/intellichat/src/app/api/chat/route.ts
+++ b/intellichat/src/app/api/chat/route.ts
@@ -104,6 +104,7 @@ export async function POST(req: Request) {
           stream : streamResponse,
           oneKey: intellinodeData ? oneKey : undefined,
           intellinodeData,
+          intelliBase: intellinodeData ? process.env.CUSTOM_INTELLIBASE_URL : undefined,
           onChunk: async (chunk: string) => {
             try {
               // Ensure proper SSE format

--- a/intellichat/src/lib/intellinode.ts
+++ b/intellichat/src/lib/intellinode.ts
@@ -142,6 +142,7 @@ type getChatResponseParams = {
   oneKey?: string;
   intellinodeData?: boolean;
   onChunk?: (chunk: string) => Promise<void>;
+  intelliBase?: string;
 };
 
 const validateProvider = (name: string) => {
@@ -174,6 +175,7 @@ export async function getChatResponse({
   oneKey,
   intellinodeData,
   onChunk,
+  intelliBase,
 }: getChatResponseParams) {
   if (!provider) {
     throw new Error('provider is required');
@@ -190,7 +192,7 @@ export async function getChatResponse({
     apiKey,
     name === 'google' ? 'gemini' : name,
     null,
-    ...(oneKey && intellinodeData ? [{ oneKey }] : [])
+    ...(oneKey && intellinodeData ? [{ oneKey, intelliBase }] : [])
   );
 
   const input = getChatInput(name, model, systemMessage);


### PR DESCRIPTION
Allow to send custom url for RAG in the environment variable.


`CUSTOM_INTELLIBASE_URL=SELF_HOSTED_INTELLI_CLOUD_URL`